### PR TITLE
JQA-0: Output an error object when it doesn't contain a response property

### DIFF
--- a/app/apiService.js
+++ b/app/apiService.js
@@ -22,7 +22,7 @@ module.exports = {
 
         const response = await _getRequest('/user/search?includeInactive=true&username=' + username)
         .catch(error => {
-            const response = error.response;
+            const response = error?.response;
             if(!response) {
                 console.log(error);
                 throw `Error ${error.code} executing request`;

--- a/app/apiService.js
+++ b/app/apiService.js
@@ -22,8 +22,11 @@ module.exports = {
 
         const response = await _getRequest('/user/search?includeInactive=true&username=' + username)
         .catch(error => {
-            console.log(error)
             const response = error.response;
+            if(!response) {
+                console.log(error);
+                throw `Error ${error.code} executing request`;
+            }
             switch(response.status) {
                 case 404: return console.log(`Username ${username} was not found`);
                 case 401: throw 'API authentication error. Please, review your credentials.';

--- a/app/apiService.js
+++ b/app/apiService.js
@@ -22,6 +22,7 @@ module.exports = {
 
         const response = await _getRequest('/user/search?includeInactive=true&username=' + username)
         .catch(error => {
+            console.log(error)
             const response = error.response;
             switch(response.status) {
                 case 404: return console.log(`Username ${username} was not found`);


### PR DESCRIPTION
Sometimes in Axios the `error` object in catch block of a request doesn't contain the `response` property. Like in one of the support cases, where there was a misconfiguration of SSL on server side.

In that case we want to console log the whole object in order to debug the problem faster (and not call anything on `undefined`, like we did on line 26).